### PR TITLE
respect -opencl argument and use proper torch.*Tensor()

### DIFF
--- a/util/SharedDropout.lua
+++ b/util/SharedDropout.lua
@@ -1,6 +1,6 @@
 local SharedDropout, Parent = torch.class('nn.SharedDropout', 'nn.Dropout')
 
-SharedDropout_noise = torch.CudaTensor()
+SharedDropout_noise = opt.opencl == 1 and torch.Tensor() or torch.CudaTensor()
 
 function SharedDropout:__init(p,v1,inplace)
    Parent.__init(self, p, v1, inplace)

--- a/util/SharedDropout.lua
+++ b/util/SharedDropout.lua
@@ -1,6 +1,6 @@
 local SharedDropout, Parent = torch.class('nn.SharedDropout', 'nn.Dropout')
 
-SharedDropout_noise = opt.opencl == 1 and torch.Tensor() or torch.CudaTensor()
+SharedDropout_noise = opt.opencl == 1 and torch.ClTensor() or torch.CudaTensor()
 
 function SharedDropout:__init(p,v1,inplace)
    Parent.__init(self, p, v1, inplace)


### PR DESCRIPTION
Hey, this is the first line of Lua I've ever written, not sure style is correct but wanted to keep it concise. 

This makes the library compatible with opencl by using the proper tensor function depending on the existence of the `-opencl  1` argument.
